### PR TITLE
Ruim table-of-contents op

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
     <section data-include-format="markdown" data-include="sections/architectuur_context.md"></section>
     <section data-include-format="markdown" data-include="sections/relatie_logboekelementen.md"></section>
     <section data-include-format="markdown" data-include="sections/canoniek_gegevensmodel.md"></section>
-    </section>
-  <section>
+  </section>
+  <section data-max-toc="1">
     <h2>Besluitenlijst</h2>
     <section data-include="docs/besluiten/00-introductie.md" data-include-format="markdown" class="informative"></section>
     <section data-include="docs/besluiten/xxxx-logregels-bevatten-alleen-wat-nodig-is-voor-verantwoording-door-verantwoordelijke.md" class="informative" data-include-format="markdown"></section>

--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
     <section data-include="docs/besluiten/xxxx-log-sampling-is-niet-toegestaan.md" class="informative" data-include-format="markdown"></section>
     <section data-include="docs/besluiten/xxxx-pseudonomiseren-gegevens.md" class="informative" data-include-format="markdown"></section>
   </section>
-  <section data-include-format="markdown" data-include="sections/ch05_voorbeelden.md"></section>
-  <section data-include-format="markdown" data-include="sections/faq.md"></section>
+  <section data-include-format="markdown" data-max-toc="1" data-include="sections/ch05_voorbeelden.md"></section>
+  <section data-include-format="markdown" data-max-toc="1" data-include="sections/faq.md"></section>
 </body>
 
 </html>


### PR DESCRIPTION
Nu voegen we niet meer alle FAQ vragen en voorbeelden in de TOC. Daarmee wordt het wat overzichtelijk om het document te begrijpen.